### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,4 +1,6 @@
 name: Jekyll site CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MrAmburgy/Security-center/security/code-scanning/1](https://github.com/MrAmburgy/Security-center/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block to the workflow to control what the GITHUB_TOKEN can access. Since the current workflow only checks out code and builds a Jekyll site in a Docker container (with no steps that require write access to the repository or GitHub API), the minimal permissions block should be set to `contents: read`. This should be added at the top level (applies to all jobs) or inside the job definition. The best approach is to place it at the workflow's root (just after the `name:` block and before `on:`) so that any future jobs will inherit least-privilege permissions unless specifically overridden. No imports, methods, or external definitions are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
